### PR TITLE
libqofonoext: Replace qVariantFromValue with QVariant::fromValue

### DIFF
--- a/src/qofonoextmodemmanager.cpp
+++ b/src/qofonoextmodemmanager.cpp
@@ -68,7 +68,7 @@ public Q_SLOTS: // METHODS
     QDBusPendingCall SetDefaultVoiceSim(const QString &aImsi)
         { return asyncCall("SetDefaultVoiceSim", aImsi); }
     QDBusPendingCall SetEnabledModems(QList<QDBusObjectPath> aModems)
-        { return asyncCall("SetEnabledModems", qVariantFromValue(aModems)); }
+        { return asyncCall("SetEnabledModems", QVariant::fromValue(aModems)); }
 
 Q_SIGNALS: // SIGNALS
     void DefaultDataModemChanged(QString aPath);


### PR DESCRIPTION
qVariantFromValue has been deprecated and QVariant::fromValue should be used instead. Qt5 provided qVariantFromValue for backwards compatibility, however as of Qt6 this will no longer work.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>