### PR TITLE
allow compilation with qt6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,14 @@
 build
 .DS_Store
 *.pro.user
+.qmake.stash
+Makefile
+plugin/Makefile
+plugin/libqofonoextdeclarative*.so*
+src/Makefile
+src/libqofonoext*.prl
+src/libqofonoext*.so*
+src/pkgconfig/
+moc_*
+*.o
+*.moc

--- a/plugin/plugin.pro
+++ b/plugin/plugin.pro
@@ -1,7 +1,7 @@
 TARGET=qofonoextdeclarative
 TEMPLATE = lib
 CONFIG += plugin link_pkgconfig
-PKGCONFIG += qofono-qt5
+PKGCONFIG += qofono-qt$${QT_MAJOR_VERSION}
 QMAKE_CXXFLAGS += -Wno-unused-parameter -Wno-psabi
 
 QT_VERSION=$$[QT_VERSION]

--- a/src/src.pro
+++ b/src/src.pro
@@ -1,6 +1,6 @@
 TARGET = qofonoext
 CONFIG += create_pc create_prl no_install_prl link_pkgconfig
-PKGCONFIG += qofono-qt5
+PKGCONFIG += qofono-qt$${QT_MAJOR_VERSION}
 
 QT += dbus
 QT -= gui


### PR DESCRIPTION
This follows https://github.com/sailfishos/libqofono/pull/14 and tries to compile next component agains qt6.
New .so contain 6 in name to avoid conflict with qt5 based version 