### PR TITLE
Q_ENUMS cannot use LLONG_MAX

### DIFF
--- a/src/qofonoextcell.h
+++ b/src/qofonoextcell.h
@@ -66,7 +66,7 @@ public:
         UNKNOWN = Unknown // For backward compatibility
     };
 
-    enum Constants {
+    enum Constants : quint64 {
         InvalidValue = INT_MAX,
         InvalidValue64 = LLONG_MAX
     };


### PR DESCRIPTION
The Q_ENUMS is deprecated and it is advised to use Q_ENUM see https://doc.qt.io/qt-6/qobject-obsolete.html#Q_ENUMS

The Q_ENUM explicitly says that enum is stored as signed int. See https://doc.qt.io/qt-6/qobject.html#Q_ENUM

In the end the `InvalidValue64 = LLONG_MAX` assignment causes that whole enum type long long, which is not allowed in Qt. I was thinking that this is probably Qt bug, but it is actually feature https://bugreports.qt.io/browse/QTBUG-119620

It leads to strange compilation error in Qt 6.6 (maybe even 6.5). See attached [build.log](https://github.com/sailfishos/libqofonoext/files/13613189/build.log). I am not sure if this solution is good or wise, but I hope it will work until we will find better solution.