### PR TITLE
Switch Nci property type as string. JB#61312

### DIFF
--- a/src/qofonoextcell.cpp
+++ b/src/qofonoextcell.cpp
@@ -55,9 +55,9 @@ class QOfonoExtCellProxy: public QDBusAbstractInterface
     Q_OBJECT
 
 public:
-    QOfonoExtCellProxy(QString aPath, QObject* aParent) :
-        QDBusAbstractInterface(OFONO_SERVICE, aPath,
-            "org.nemomobile.ofono.Cell", OFONO_BUS, aParent) {}
+    QOfonoExtCellProxy(const QString &aPath, QObject *aParent)
+        : QDBusAbstractInterface(OFONO_SERVICE, aPath,
+                                 "org.nemomobile.ofono.Cell", OFONO_BUS, aParent) {}
 
 public Q_SLOTS: // METHODS
     QDBusPendingCall GetAllAsync()
@@ -234,10 +234,9 @@ void QOfonoExtCell::Private::updateAllAsync()
             getAllAsync();
         }
     } else {
-        if (iPendingGetAll) {
-            delete iPendingGetAll;
-            iPendingGetAll = Q_NULLPTR;
-        }
+        delete iPendingGetAll;
+        iPendingGetAll = Q_NULLPTR;
+
         if (iValid) {
             iValid = false;
             Q_EMIT cell()->validChanged();
@@ -258,10 +257,9 @@ int QOfonoExtCell::Private::inRange(int aValue, int aMin, int aMax)
 
 void QOfonoExtCell::Private::getAllSyncInit()
 {
-    if (iPendingGetAll) {
-        delete iPendingGetAll;
-        iPendingGetAll = NULL;
-    }
+    delete iPendingGetAll;
+    iPendingGetAll = NULL;
+
     GetAllReply reply(GetAllSync());
     if (!reply.isError()) {
         handleGetAllReply(reply, false);

--- a/src/qofonoextcell.cpp
+++ b/src/qofonoextcell.cpp
@@ -58,7 +58,7 @@ public Q_SLOTS: // METHODS
         { return call(kMethodGetAll); }
 
 Q_SIGNALS: // SIGNALS
-    void PropertyChanged(QString aName, QDBusVariant aValue);
+    void PropertyChanged(const QString &aName, const QDBusVariant &aValue);
     void RegisteredChanged(bool aRegistered);
     void Removed();
 };
@@ -94,12 +94,12 @@ public:
         QVariantMap>  // 3. properties
         GetAllReply;
 
-    Private(QString aPath, QOfonoExtCell* aParent);
+    Private(const QString &aPath, QOfonoExtCell *aParent);
     void getAllSyncInit();
 
     static int valueInt(Private* aThis, Property aProperty);
-    static Type typeFromString(QString aType);
-    static Property propertyFromString(QString aProperty);
+    static Type typeFromString(const QString &aType);
+    static Property propertyFromString(const QString &aProperty);
     static int getRssiDbm(int aSignalStrength);
     static int inRange(int aValue, int aRangeMin, int aRangeMax);
 
@@ -117,7 +117,7 @@ public Q_SLOTS:
 
 private Q_SLOTS:
     void onGetAllFinished(QDBusPendingCallWatcher* aWatcher);
-    void onPropertyChanged(QString aName, QDBusVariant aValue);
+    void onPropertyChanged(const QString &aName, const QDBusVariant &aValue);
     void onRegisteredChanged(bool aRegistered);
 
 public:
@@ -143,7 +143,7 @@ const QOfonoExtCell::Private::PropertyDesc QOfonoExtCell::Private::Properties[] 
     CELL_PROPERTIES(PropertyDesc_)
 };
 
-QOfonoExtCell::Private::Private(QString aPath, QOfonoExtCell* aParent) :
+QOfonoExtCell::Private::Private(const QString &aPath, QOfonoExtCell *aParent) :
     QOfonoExtCellProxy(aPath, aParent),
     iValid(false),
     iRegistered(false),
@@ -176,7 +176,7 @@ inline QOfonoExtCell* QOfonoExtCell::Private::cell()
     return qobject_cast<QOfonoExtCell*>(parent());
 }
 
-QOfonoExtCell::Type QOfonoExtCell::Private::typeFromString(QString aType)
+QOfonoExtCell::Type QOfonoExtCell::Private::typeFromString(const QString &aType)
 {
     return (aType == kTypeGsm) ? GSM :
            (aType == kTypeLte) ? LTE :
@@ -185,7 +185,7 @@ QOfonoExtCell::Type QOfonoExtCell::Private::typeFromString(QString aType)
            UNKNOWN;
 }
 
-QOfonoExtCell::Private::Property QOfonoExtCell::Private::propertyFromString(QString aProperty)
+QOfonoExtCell::Private::Property QOfonoExtCell::Private::propertyFromString(const QString &aProperty)
 {
     for (int i=PropertyUnknown+1; i<PropertyCount; i++) {
         if (Properties[i].name == aProperty) {
@@ -348,7 +348,7 @@ void QOfonoExtCell::Private::invalidateValues()
     iNci = INT64_MAX;
 }
 
-void QOfonoExtCell::Private::onPropertyChanged(QString aName, QDBusVariant aValue)
+void QOfonoExtCell::Private::onPropertyChanged(const QString &aName, const QDBusVariant &aValue)
 {
     bool ok = false;
     int intValue = aValue.variant().toInt(&ok);

--- a/src/qofonoextcell.h
+++ b/src/qofonoextcell.h
@@ -44,7 +44,8 @@ class QOFONOEXT_EXPORT QOfonoExtCell : public QObject
     Q_PROPERTY(int rssnr READ rssnr NOTIFY rssnrChanged)
     Q_PROPERTY(int cqi READ cqi NOTIFY cqiChanged)
     Q_PROPERTY(int timingAdvance READ timingAdvance NOTIFY timingAdvanceChanged)
-    Q_PROPERTY(qint64 nci READ nci NOTIFY nciChanged)
+    // string to allow easy usage from qml
+    Q_PROPERTY(QString nci READ nciString NOTIFY nciChanged)
     Q_PROPERTY(int nrarfcn READ nrarfcn NOTIFY nrarfcnChanged)
     Q_PROPERTY(int ssRsrp READ ssRsrp NOTIFY ssRsrpChanged)
     Q_PROPERTY(int ssRsrq READ ssRsrq NOTIFY ssRsrqChanged)
@@ -67,8 +68,7 @@ public:
     };
 
     enum Constants {
-        InvalidValue = INT_MAX,
-        InvalidValue64 = LLONG_MAX
+        InvalidValue = INT_MAX
     };
 
     explicit QOfonoExtCell(QObject* aParent = Q_NULLPTR);
@@ -116,7 +116,7 @@ public:
     int tac() const;
 
     // NR:
-    qint64 nci() const;
+    QString nciString() const;
     int nrarfcn() const;
     int ssRsrp() const;
     int ssRsrq() const;
@@ -159,7 +159,6 @@ Q_SIGNALS:
     void csiSinrChanged();
     void signalLevelDbmChanged();
     void propertyChanged(QString name, int value); // int properties
-    void propertyChanged64(QString name, qint64 value); // 64-bit properties
     void removed();
 
 private:

--- a/src/qofonoextmodemmanager.h
+++ b/src/qofonoextmodemmanager.h
@@ -40,7 +40,7 @@ class QOFONOEXT_EXPORT QOfonoExtModemManager : public QObject
     Q_PROPERTY(int errorCount READ errorCount NOTIFY errorCountChanged)
 
 public:
-    explicit QOfonoExtModemManager(QObject* aParent = NULL);
+    explicit QOfonoExtModemManager(QObject *parent = nullptr);
     ~QOfonoExtModemManager();
 
     bool valid() const;


### PR DESCRIPTION
Main commit:

    The qint64 type was problematic:
    - Doesn't work in QML
    - The Invalid64 on enum doesn't work without declaring the
    enum as 64 bit. Which again might not be the best idea for qml.
    - App developer needs to pay close attention whether to use
    32-bit or 64-bit invalid value.
    
    As this isn't getting used in the wild yet, let's just switch
    the nci property as string for now. If there are c++ needs, a
    separate getter can be added later.
    
    The general 64-bit storage just because of one wider property, now
    needing more special handling, felt heavy. Switched back to 32-bit and
    using separate property for nci. Wouldn't expect new radio
    technologies with new properties too soon.

In addition couple small cleanup commits.

As side-note the existing change signalling here feels excessive with separate signal for each property plus one generic propertyChanged() for int properties. If a cell changes, could assume all the cell properties changing. Only signal strength and that kind of details probably change independently.

Disclaimer: don't have NR to test this with.