### PR TITLE
Allow building with cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,47 @@
+cmake_minimum_required(VERSION 3.12.0 FATAL_ERROR)
+
+set(LIBQOFONOEXT_VERSION "1.0.32" CACHE STRING "libqofonoext version")
+set(QT_MAJOR_VERSION 5 CACHE STRING "Qt major version")
+
+project(libqofonoext
+    VERSION ${LIBQOFONOEXT_VERSION}
+    DESCRIPTION "Library for accessing Sailfish OS specific ofono extensions"
+    HOMEPAGE_URL "https://github.com/sailfishos/libqofonoext"
+    LANGUAGES CXX
+)
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTOUIC ON)
+
+include(GNUInstallDirs)
+include(FeatureSummary)
+find_package(Qt5 COMPONENTS DBus Qml)
+find_package(PkgConfig)
+
+pkg_check_modules(QOFONO_QT REQUIRED qofono-qt${QT_MAJOR_VERSION})
+
+set_package_properties(Qt5
+    PROPERTIES
+    TYPE REQUIRED
+    DESCRIPTION "Qt5 libraries"
+    URL "https://www.qt.io"
+)
+
+set_package_properties(PkgConfig
+    PROPERTIES
+    TYPE REQUIRED
+    DESCRIPTION "Helper tool for compiling applications and libraries"
+    URL "https://www.freedesktop.org/wiki/Software/pkg-config/"
+)
+
+set_package_properties(QOFONO_QT
+    PROPERTIES
+    TYPE REQUIRED
+    DESCRIPTION "Library for accessing the ofono daemon"
+    URL "https://github.com/sailfishos/libqofono"
+)
+
+feature_summary(WHAT REQUIRED_PACKAGES_NOT_FOUND FATAL_ON_MISSING_REQUIRED_PACKAGES)
+
+add_subdirectory(src)
+add_subdirectory(plugin)

--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -1,0 +1,43 @@
+project(qofonoextdeclarative LANGUAGES CXX)
+
+set(PLUGIN_SOURCES
+    qofonoextdeclarativeplugin.cpp
+    qofonoextmodemlistmodel.cpp
+    qofonoextsimlistmodel.cpp
+)
+
+add_library(qofonoextdeclarative SHARED ${PLUGIN_SOURCES})
+
+target_include_directories(qofonoextdeclarative PRIVATE
+    ${CMAKE_SOURCE_DIR}/src ${QOFONO_QT_INCLUDE_DIRS}
+)
+
+target_link_libraries(qofonoextdeclarative PRIVATE
+    Qt5::Qml
+    Qt5::DBus
+    qofonoext
+    ${QOFONO_QT_LIBRARIES}
+)
+
+# Set the output directory for the plugin and copy the qmldir file 
+# to the appropriate location for qmlplugindump to find it.
+set_target_properties(qofonoextdeclarative PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/org/nemomobile/ofono
+)
+configure_file(qmldir ${CMAKE_CURRENT_BINARY_DIR}/org/nemomobile/ofono/qmldir COPYONLY)
+
+find_program(QMLPLUGINDUMP_CMD NAMES qmlplugindump-qt5 qmlplugindump)
+
+add_custom_target(qmltypes
+    COMMAND ${CMAKE_COMMAND} -E env "QML2_IMPORT_PATH=${CMAKE_CURRENT_BINARY_DIR}" ${QMLPLUGINDUMP_CMD} -nonrelocatable org.nemomobile.ofono 1.0 > ${CMAKE_CURRENT_SOURCE_DIR}/plugins.qmltypes
+    DEPENDS qofonoextdeclarative
+    COMMENT "Generating plugins.qmltypes"
+)
+
+install(TARGETS qofonoextdeclarative
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/qt5/qml/org/nemomobile/ofono
+)
+
+install(FILES qmldir plugins.qmltypes
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/qt5/qml/org/nemomobile/ofono
+)

--- a/rpm/libqofonoext.spec
+++ b/rpm/libqofonoext.spec
@@ -1,7 +1,7 @@
 Name:       libqofonoext
 
 Summary:    A library of Qt bindings for ofono extensions
-Version:    1.0.31
+Version:    1.0.32
 Release:    1
 License:    LGPLv2
 URL:        https://github.com/sailfishos/libqofonoext

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,50 @@
+add_library(
+    qofonoext SHARED
+    qofonoext.cpp
+    qofonoextcell.cpp
+    qofonoextcellinfo.cpp
+    qofonoextcellwatcher.cpp
+    qofonoextmodemmanager.cpp
+    qofonoextsiminfo.cpp
+)
+
+set(PUBLIC_HEADER_FILES
+    qofonoextcell.h
+    qofonoextcellinfo.h
+    qofonoextcellwatcher.h
+    qofonoextmodemmanager.h
+    qofonoextsiminfo.h
+    qofonoext_types.h
+)
+
+set_target_properties(
+    qofonoext
+    PROPERTIES
+    VERSION ${PROJECT_VERSION}
+    SOVERSION ${PROJECT_VERSION_MAJOR}
+)
+
+target_compile_definitions(qofonoext PRIVATE QOFONOEXT_LIBRARY)
+target_compile_options(qofonoext PRIVATE -Wno-unused-parameter -Wno-psabi)
+
+target_include_directories(qofonoext PRIVATE ${QOFONO_QT_INCLUDE_DIRS})
+target_link_libraries(qofonoext PRIVATE ${QOFONO_QT_LIBRARIES} Qt5::DBus)
+
+### INSTALL ###
+
+# Library
+install(TARGETS qofonoext
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+# Public headers
+install(FILES ${PUBLIC_HEADER_FILES}
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/qofonoext
+)
+
+# pkg-config file (qmake create_pc)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/qofonoext.pc.in ${CMAKE_CURRENT_BINARY_DIR}/qofonoext.pc @ONLY)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/qofonoext.pc
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+)

--- a/src/qofonoext.pc.in
+++ b/src/qofonoext.pc.in
@@ -1,0 +1,12 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/lib
+includedir=${prefix}/include/qofonoext
+
+
+Name: qofonoext
+Description: Qt bindings for ofono extensions
+Version: @PROJECT_VERSION@
+Libs: -lqofonoext 
+Cflags: -I${includedir}
+

--- a/src/version.pri
+++ b/src/version.pri
@@ -1,1 +1,1 @@
-VERSION = 1.0.31
+VERSION = 1.0.32


### PR DESCRIPTION
Implements building libQOfonoext with cmake instead of qmake

See: https://gitlab.com/ubports/development/core/packaging/libqofonoext/-/issues/1

See: https://github.com/sailfishos/libqofono/pull/25